### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,12 @@ jobs:
           mingw-w64-${{ matrix.arch }}-gcc-fortran
           mingw-w64-${{ matrix.arch }}-openblas
           mingw-w64-${{ matrix.arch }}-lapack
-          mingw-w64-${{ matrix.arch }}-meson
+          mingw-w64-${{ matrix.arch }}-python
+          mingw-w64-${{ matrix.arch }}-python-pip
           mingw-w64-${{ matrix.arch }}-ninja
+
+    - name: Install meson
+      run: pip3 install meson==0.55.3
 
     - name: Configure meson build
       run: meson setup ${{ env.BUILD_DIR }}

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "multicharge"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 author = ["Sebastian Ehlert"]
 maintainer = ["@awvwgk"]

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@
 project(
   'multicharge',
   'fortran',
-  version: '0.1.0',
+  version: '0.1.1',
   license: 'Apache-2.0',
   meson_version: '>=0.53',
   default_options: [

--- a/src/multicharge/version.f90
+++ b/src/multicharge/version.f90
@@ -23,10 +23,10 @@ module multicharge_version
 
 
    !> String representation of the multicharge version
-   character(len=*), parameter :: multicharge_version_string = "0.1.0"
+   character(len=*), parameter :: multicharge_version_string = "0.1.1"
 
    !> Numeric representation of the multicharge version
-   integer, parameter :: multicharge_version_compact(3) = [0, 1, 0]
+   integer, parameter :: multicharge_version_compact(3) = [0, 1, 1]
 
 
 contains


### PR DESCRIPTION
New release required for `dftd4` and `mkl_rt` support.