### PR TITLE
Link against `BLAS::BLAS` when CMake version is less than 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
   PUBLIC
   "${lib-deps}"
   "LAPACK::LAPACK"
+  "$<$<VERSION_LESS:${CMAKE_VERSION},3.20>:BLAS::BLAS>"
 )
 if(WITH_OpenMP)
   target_link_libraries(


### PR DESCRIPTION
When CMake version is less than 3.20, `LAPACK::LAPACK` is not linked against `BLAS::BLAS`—see [FindLAPACK@3.19.8](https://gitlab.kitware.com/cmake/cmake/-/blob/v3.19.8/Modules/FindLAPACK.cmake#L542-544) vs [FindLAPACK@3.20.0](https://gitlab.kitware.com/cmake/cmake/-/blob/v3.20.0/Modules/FindLAPACK.cmake#L135-138).

The current CMakeLists.txt works with BLAS/LAPACK such as OpenBLAS and MKL, but not with netlib:
```shellsession
$ mkdir build; cd build
$ cmake -GNinja ..
…
-- Looking for Fortran sgemm
-- Looking for Fortran sgemm - not found
-- Looking for Fortran sgemm
-- Looking for Fortran sgemm - found
-- Found BLAS: /usr/lib64/libblas.so  
-- Looking for Fortran cheev
-- Looking for Fortran cheev - found
-- Found LAPACK: /usr/lib64/liblapack.so;/usr/lib64/libblas.so  
…
$ ninja -v
[129/140] : && /usr/bin/f95  -O2 -g -DNDEBUG app/CMakeFiles/multicharge-exe.dir/main.f90.o -o app/multicharge  libmulticharge.a  _deps/mctc-lib-build/libmctc-lib.a  /usr/lib64/liblapack.so  /usr/lib/gcc/x86_64-redhat-linux/8/libgomp.so  /usr/lib64/libpthread.so && :
FAILED: app/multicharge 
: && /usr/bin/f95  -O2 -g -DNDEBUG app/CMakeFiles/multicharge-exe.dir/main.f90.o -o app/multicharge  libmulticharge.a  _deps/mctc-lib-build/libmctc-lib.a  /usr/lib64/liblapack.so  /usr/lib/gcc/x86_64-redhat-linux/8/libgomp.so  /usr/lib64/libpthread.so && :
/usr/bin/ld: libmulticharge.a(blas.f90.o): undefined reference to symbol 'dgemm_'
//usr/lib64/libblas.so.3: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

