### PR TITLE
Treat Intel LLVM compiler as standard Intel compiler.  

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -16,7 +16,10 @@
 os = host_machine.system()
 fc = meson.get_compiler('fortran')
 fc_id = fc.get_id()
-
+# Treat Intel LLVM compiler as standard Intel compiler for compatibility
+if fc_id == 'intel-llvm'
+  fc_id = 'intel'
+endif
 if fc_id == 'gcc'
   add_project_arguments(
     '-ffree-line-length-none',

--- a/config/meson.build
+++ b/config/meson.build
@@ -16,6 +16,7 @@
 os = host_machine.system()
 fc = meson.get_compiler('fortran')
 fc_id = fc.get_id()
+
 # Treat Intel LLVM compiler as standard Intel compiler for compatibility
 if fc_id == 'intel-llvm'
   fc_id = 'intel'


### PR DESCRIPTION
See https://github.com/dftd4/dftd4/issues/252#issuecomment-2270221103 for a more detailed related discussion.

These changes ensure that the Intel LLVM compiler is treated as the standard Intel compiler, addressing specific compatibility issues we've encountered.