### PR TITLE
Make flags for gradient evaluation more consistent

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -216,7 +216,7 @@ subroutine get_arguments(input, input_format, grad, charge, json, error)
             call fatal_error(error, "Invalid charge value")
             exit
          end if
-      case("-grad", "--grad")
+      case("-g", "--grad")
          grad = .true.
       case("-j", "--json")
          json = .true.

--- a/app/main.f90
+++ b/app/main.f90
@@ -128,12 +128,12 @@ subroutine help(unit)
       ""
 
    write(unit, '(2x, a, t25, a)') &
-      "-i, --input <format>", "Hint for the format of the input file", &
-      "-c, --charge <value>", "Set the molecular charge", &
-      "-g, --grad", "Evaluate molecular gradient and virial", &
-      "-j, --json", "Provide output in JSON format to the file 'multicharge.json'", &
-      "-v, --version", "Print program version and exit", &
-      "-h, --help", "Show this help message"
+      "-i, -input, --input <format>", "Hint for the format of the input file", &
+      "-c, -charge, --charge <value>", "Set the molecular charge", &
+      "-g, -grad, --grad", "Evaluate molecular gradient and virial", &
+      "-j, -json, --json", "Provide output in JSON format to the file 'multicharge.json'", &
+      "-v, -version, --version", "Print program version and exit", &
+      "-h, -help, --help", "Show this help message"
 
    write(unit, '(a)')
 
@@ -218,7 +218,7 @@ subroutine get_arguments(input, input_format, grad, charge, json, error)
          end if
       case("-g", "-grad", "--grad")
          grad = .true.
-      case("-j", "--json")
+      case("-j", "-json", "--json")
          json = .true.
       end select
    end do

--- a/app/main.f90
+++ b/app/main.f90
@@ -216,7 +216,7 @@ subroutine get_arguments(input, input_format, grad, charge, json, error)
             call fatal_error(error, "Invalid charge value")
             exit
          end if
-      case("-g", "--grad")
+      case("-g", "-grad", "--grad")
          grad = .true.
       case("-j", "--json")
          json = .true.

--- a/man/multicharge.1.adoc
+++ b/man/multicharge.1.adoc
@@ -14,17 +14,20 @@ Electronegativity equilibration model for atomic partial charges.
 
 == Options
 
-*-i, --input* _format_::
+*-i, -input, --input* _format_::
 Hint for the format of the input file
 
-*--json*::
+*-c, -charge, --charge* _value_::
+Provide the molecular charge
+
+*-j, -json, --json*::
 Provide output in JSON format to the file 'multicharge.json'
 
-*-g, --grad*::
+*-g, -grad, --grad*::
 Evaluate molecular gradient and virial
 
-*--version*::
+*-v, -version, --version*::
 Print program version and exit
 
-*--help*::
+*-h, -help, --help*::
 Show this help message

--- a/man/multicharge.1.adoc
+++ b/man/multicharge.1.adoc
@@ -20,7 +20,7 @@ Hint for the format of the input file
 *--json*::
 Provide output in JSON format to the file 'multicharge.json'
 
-*--grad*::
+*-g, --grad*::
 Evaluate molecular gradient and virial
 
 *--version*::


### PR DESCRIPTION
Before, the documentation (via `--help`) and the actually read arguments from CLI were not consistent. 
With this PR, both `-g` and `--grad` are possible.