### PR TITLE
Fix mctc-lib version to 0.4.0

### DIFF
--- a/config/cmake/Findmctc-lib.cmake
+++ b/config/cmake/Findmctc-lib.cmake
@@ -16,7 +16,7 @@
 set(_lib "mctc-lib")
 set(_pkg "MCTCLIB")
 set(_url "https://github.com/grimme-lab/mctc-lib")
-set(_rev "HEAD")
+set(_rev "v0.4.0")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")

--- a/config/meson.build
+++ b/config/meson.build
@@ -147,7 +147,7 @@ mctc_dep = dependency('mctc-lib', required: false)
 if not mctc_dep.found()
   mctc_prj = subproject(
     'mctc-lib',
-    version: '>=0.3.0',
+    version: '>=0.4.0',
     default_options: [
       'default_library=static',
     ],

--- a/fpm.toml
+++ b/fpm.toml
@@ -10,7 +10,7 @@ link = ["lapack", "blas"]
 
 [dependencies]
 mctc-lib.git = "https://github.com/grimme-lab/mctc-lib.git"
-mctc-lib.tag = "HEAD"
+mctc-lib.tag = "v0.4.0"
 
 [dev-dependencies]
 mstore.git = "https://github.com/grimme-lab/mstore.git"

--- a/subprojects/mctc-lib.wrap
+++ b/subprojects/mctc-lib.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = mctc-lib
 url = https://github.com/grimme-lab/mctc-lib
-revision = head
+revision = v0.4.0


### PR DESCRIPTION
Increases also the minimum version for mctc-lib to 0.4.0 to get the coordination number. 