### PR TITLE
Fix multiple bugs in wignerseitz.f90

### DIFF
--- a/src/multicharge/wignerseitz.f90
+++ b/src/multicharge/wignerseitz.f90
@@ -45,28 +45,34 @@ subroutine new_wignerseitz_cell(self, mol)
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
 
-   integer :: iat, jat, ntr, nimg
+   integer :: iat, jat, ntr, nimg, nimg_max
    integer, allocatable :: tridx(:)
    real(wp) :: vec(3)
    real(wp), allocatable :: trans(:, :)
 
    call get_lattice_points(mol%periodic, mol%lattice, thr, trans)
    ntr = size(trans, 2)
-   allocate(self%nimg(mol%nat, mol%nat), self%tridx(ntr, mol%nat, mol%nat), &
-      & tridx(ntr))
+   allocate(self%nimg(mol%nat, mol%nat), self%tridx(ntr, mol%nat, mol%nat))
 
-   self%nimg_max = 0
-   !$omp parallel do default(none) schedule(runtime) collapse(2) &
-   !$omp shared(mol, trans, self) private(iat, jat, vec, nimg, tridx)
+   nimg_max = 0
+   !$omp parallel default(none) &
+   !$omp shared(mol, trans, self, ntr) private(iat, jat, vec, nimg, tridx) &
+   !$omp reduction(max:nimg_max)
+   allocate(tridx(ntr))
+   !$omp do collapse(2) schedule(runtime)
    do iat = 1, mol%nat
       do jat = 1, mol%nat
          vec(:) = mol%xyz(:, iat) - mol%xyz(:, jat)
          call get_pairs(nimg, trans, vec, tridx)
          self%nimg(jat, iat) = nimg
          self%tridx(:, jat, iat) = tridx
-         self%nimg_max = max(nimg, self%nimg_max)
+         nimg_max = max(nimg, nimg_max)
       end do
    end do
+   !$omp end do
+   deallocate(tridx)
+   !$omp end parallel
+   self%nimg_max = nimg_max
 
    call move_alloc(trans, self%trans)
 
@@ -107,6 +113,7 @@ subroutine get_pairs(iws, trans, rij, list)
    if (img <= iws) return
 
    do
+      if (iws >= img) exit
       pos = minloc(dist(:img), dim=1, mask=mask(:img))
       if (abs(dist(pos) - r2) > tol) exit
       mask(pos) = .false.


### PR DESCRIPTION
The patch fixes three bugs in wignerseitz.f90:

 1. Unallocated private allocatable (tridx): Per OpenMP spec §2.15.3.3, private copies of allocatables start unallocated. The original code allocated tridx before the parallel region then listed it as private, causing undefined behavior when get_pairs tried to use the unallocated array. Fixed by allocating tridx inside the parallel region (same pattern used correctly in eeq.f90).
 2. Race condition on self%nimg_max: Multiple threads wrote self%nimg_max = max(nimg, self%nimg_max) simultaneously without synchronization. Fixed with a local variable and reduction(max:nimg_max).
 3. Missing termination in get_pairs do-loop: When all img translations happen to be equidistant (e.g., in high-symmetry crystals), the loop would exhaust all mask entries, then minloc with an all-false mask returns pos=0 (undefined per Fortran standard, gfortran returns 0), causing dist(0) out-of-bounds. Fixed with if (iws >= img) exit guard.

The original symptom was the crash in the pbc testcase.